### PR TITLE
Fix missing `subcommand` argument in metric arguments

### DIFF
--- a/includes/metrisca.hpp
+++ b/includes/metrisca.hpp
@@ -11,6 +11,7 @@
 
 #include "metrisca/version.hpp"
 
+#include "metrisca/core/assert.hpp"
 #include "metrisca/core/plugin.hpp"
 #include "metrisca/core/matrix.hpp"
 #include "metrisca/core/errors.hpp"

--- a/includes/metrisca/core/assert.hpp
+++ b/includes/metrisca/core/assert.hpp
@@ -1,0 +1,23 @@
+/**
+ * MetriSCA - A side-channel analysis library
+ * Copyright 2021, School of Computer and Communication Sciences, EPFL.
+ *
+ * All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE.md file.
+ */
+
+#pragma once
+
+#include <cassert>
+
+namespace metrisca {
+
+#if defined(DEBUG)
+#define METRISCA_ASSERT(check) { assert(check); }
+#define METRISCA_ASSERT_NOT_REACHED() { assert(false && "Non-reachable code was executed."); }
+#else
+#define METRISCA_ASSERT(check)
+#define METRISCA_ASSERT_NOT_REACHED()
+#endif
+
+}

--- a/includes/metrisca/core/matrix.hpp
+++ b/includes/metrisca/core/matrix.hpp
@@ -11,10 +11,10 @@
 
 #include "metrisca/core/result.hpp"
 #include "metrisca/core/errors.hpp"
+#include "metrisca/core/assert.hpp"
 
 #include <vector>
 #include <cstdint>
-#include <cassert>
 #include <fstream>
 
 #include <nonstd/span.hpp>
@@ -63,21 +63,21 @@ namespace metrisca {
         /// Set a row of the matrix
         void SetRow(size_type row_index, const ptr_type row_data)
         {
-            assert(row_index < this->m_Height);
+            METRISCA_ASSERT(row_index < this->m_Height);
 
             std::copy(row_data, row_data + this->m_Width, this->m_Data.begin() + (row_index * this->m_Width));
         }
 
         void SetRow(size_type row_index, const std::vector<value_type>& row)
         {
-            assert(row.size() == this->m_Width);
+            METRISCA_ASSERT(row.size() == this->m_Width);
 
             SetRow(row_index, (const ptr_type)row.data());
         }
 
         void SetRow(size_type row_index, const nonstd::span<const value_type>& row)
         {
-            assert(row.size() == this->m_Width);
+            METRISCA_ASSERT(row.size() == this->m_Width);
 
             SetRow(row_index, (const ptr_type)row.data());
         }
@@ -85,7 +85,7 @@ namespace metrisca {
         /// Fill a row of this matrix with a constant value
         void FillRow(size_type row_index, const value_type& value)
         {
-            assert(row_index < this->m_Height);
+            METRISCA_ASSERT(row_index < this->m_Height);
 
             std::fill(this->m_Data.begin() + (row_index * this->m_Width), this->m_Data.begin() + ((row_index + 1) * this->m_Width), value);
         }
@@ -95,7 +95,7 @@ namespace metrisca {
         /// read-only view of the row.
         nonstd::span<const value_type> GetRow(size_type row_index) const
         {
-            assert(row_index < this->m_Height);
+            METRISCA_ASSERT(row_index < this->m_Height);
 
             nonstd::span<const value_type> span(this->m_Data);
             return span.subspan(row_index * this->m_Width, this->m_Width);
@@ -104,13 +104,13 @@ namespace metrisca {
         /// Extract a submatrix from this matrix. The row and column upper bounds are not inclusive.
         Matrix<value_type> Submatrix(size_type row_start, size_type col_start, size_type row_end, size_type col_end) const
         {
-            assert(row_start < this->m_Height);
-            assert(row_end <=  this->m_Height);
-            assert(row_start < row_end);
+            METRISCA_ASSERT(row_start < this->m_Height);
+            METRISCA_ASSERT(row_end <=  this->m_Height);
+            METRISCA_ASSERT(row_start < row_end);
 
-            assert(col_start < this->m_Width);
-            assert(col_end <= this->m_Width);
-            assert(col_start < col_end);
+            METRISCA_ASSERT(col_start < this->m_Width);
+            METRISCA_ASSERT(col_end <= this->m_Width);
+            METRISCA_ASSERT(col_start < col_end);
 
             Matrix<value_type> result(col_end - col_start, row_end - row_start);
 
@@ -127,12 +127,12 @@ namespace metrisca {
         /// Element-wise accessor
         value_type& operator()(size_type row, size_type col)
         {
-            assert(row < m_Height && col < m_Width);
+            METRISCA_ASSERT(row < m_Height && col < m_Width);
             return this->m_Data[row * m_Width + col];
         }
         const value_type& operator()(size_type row, size_type col) const
         {
-            assert(row < m_Height && col < m_Width);
+            METRISCA_ASSERT(row < m_Height && col < m_Width);
             return this->m_Data[row * m_Width + col];
         }
 

--- a/includes/metrisca/core/trace_dataset.hpp
+++ b/includes/metrisca/core/trace_dataset.hpp
@@ -10,11 +10,11 @@
 
 #include "metrisca/core/matrix.hpp"
 #include "metrisca/core/result.hpp"
+#include "metrisca/core/assert.hpp"
 
 #include <nonstd/span.hpp>
 #include <vector>
 #include <string>
-#include <cassert>
 #include <unordered_map>
 #include <memory>
 
@@ -33,7 +33,7 @@ namespace metrisca {
         case EncryptionAlgorithm::UNKNOWN: return "unknown";
         case EncryptionAlgorithm::S_BOX: return "s-box";
         case EncryptionAlgorithm::AES_128: return "aes-128";
-        default: assert(false); return "unknown";
+        default: METRISCA_ASSERT_NOT_REACHED(); return "unknown";
         }
     }
 

--- a/src/metrisca/core/trace_dataset.cpp
+++ b/src/metrisca/core/trace_dataset.cpp
@@ -13,7 +13,6 @@
 #include "metrisca/utils/numerics.hpp"
 
 #include <fstream>
-#include <cassert>
 #include <cstdint>
 
 namespace metrisca {
@@ -61,7 +60,7 @@ namespace metrisca {
         }
         else
         {
-            assert(false);
+            METRISCA_ASSERT_NOT_REACHED();
         }
     }
     
@@ -99,7 +98,7 @@ namespace metrisca {
                     plaintext_load_count = 1; // Load only the first plaintext and generate the others
                 } break;
                 default: {
-                    assert(false);
+                    METRISCA_ASSERT_NOT_REACHED();
                 } break;
             }
             result->m_Plaintexts = Matrix<uint8_t>(result->m_Header.PlaintextSize, plaintext_count);
@@ -113,7 +112,7 @@ namespace metrisca {
                     key_count = 1;
                 } break;
                 default: {
-                    assert(false);
+                    METRISCA_ASSERT_NOT_REACHED();
                 } break;
             }
             result->m_Keys = Matrix<uint8_t>(result->m_Header.KeySize, key_count);
@@ -161,7 +160,7 @@ namespace metrisca {
             return this->m_Plaintexts.GetRow(trace);
         }
         default: {
-            assert(false);
+            METRISCA_ASSERT_NOT_REACHED();
             return nonstd::span<const uint8_t>();
         }
         }
@@ -175,7 +174,7 @@ namespace metrisca {
             return this->m_Keys.GetRow(0);
         }
         default: {
-            assert(false);
+            METRISCA_ASSERT_NOT_REACHED();
             return nonstd::span<const uint8_t>();
         }
         }
@@ -200,7 +199,7 @@ namespace metrisca {
         }
         default:
         {
-            assert(false);
+            METRISCA_ASSERT_NOT_REACHED();
             return nonstd::span<const uint8_t>();
         }
         }
@@ -221,7 +220,7 @@ namespace metrisca {
 
     void TraceDataset::SplitDataset(TraceDataset& out1, TraceDataset& out2, uint32_t trace_split) const
     {
-        assert(trace_split < m_Header.NumberOfTraces);
+        METRISCA_ASSERT(trace_split < m_Header.NumberOfTraces);
 
         out1.m_Header = m_Header;
         out2.m_Header = m_Header;
@@ -260,7 +259,7 @@ namespace metrisca {
             out2.m_Ciphertexts = m_Ciphertexts.Submatrix(out1.m_Header.NumberOfTraces, 0, m_Header.NumberOfTraces, m_Header.PlaintextSize);
         } break;
         default: {
-            assert(false);
+            METRISCA_ASSERT_NOT_REACHED();
         }
         }
 
@@ -272,7 +271,7 @@ namespace metrisca {
             out2.m_Keys = m_Keys.Copy();
         } break;
         default: {
-            assert(false);
+            METRISCA_ASSERT_NOT_REACHED();
         }
         }
     }
@@ -293,8 +292,8 @@ namespace metrisca {
         } break;
         case EncryptionAlgorithm::AES_128: {
             // Copy key and first plaintext from provided user data
-            assert(this->m_Keys.GetWidth() == AES128_BLOCK_SIZE);
-            assert(this->m_Plaintexts.GetWidth() == AES128_BLOCK_SIZE);
+            METRISCA_ASSERT(this->m_Keys.GetWidth() == AES128_BLOCK_SIZE);
+            METRISCA_ASSERT(this->m_Plaintexts.GetWidth() == AES128_BLOCK_SIZE);
             std::array<uint8_t, AES128_BLOCK_SIZE> key;
             for (size_t i = 0; i < key.size(); ++i)
                 key[i] = this->m_Keys(0, i);
@@ -314,7 +313,7 @@ namespace metrisca {
             }
         } break;
         default: {
-            assert(false);
+            METRISCA_ASSERT_NOT_REACHED();
         }
         }
     }
@@ -338,7 +337,7 @@ namespace metrisca {
         } break;
         default:
         {
-            assert(false);
+            METRISCA_ASSERT_NOT_REACHED();
             return;
         }
         }
@@ -375,7 +374,7 @@ namespace metrisca {
         } break;
         default:
         {
-            assert(false);
+            METRISCA_ASSERT_NOT_REACHED();
         }
         }
     }
@@ -407,7 +406,7 @@ namespace metrisca {
             {
             case EncryptionAlgorithm::S_BOX: this->PlaintextSize = 1; break;
             case EncryptionAlgorithm::AES_128: this->PlaintextSize = 16; break;
-            default: assert(false); return Error::INVALID_DATA;
+            default: METRISCA_ASSERT_NOT_REACHED(); return Error::INVALID_DATA;
             }
         }
 
@@ -417,7 +416,7 @@ namespace metrisca {
             {
             case EncryptionAlgorithm::S_BOX: this->KeySize = 1; break;
             case EncryptionAlgorithm::AES_128: this->KeySize = 16; break;
-            default: assert(false); return Error::INVALID_DATA;
+            default: METRISCA_ASSERT_NOT_REACHED(); return Error::INVALID_DATA;
             }
         }
 
@@ -456,7 +455,7 @@ namespace metrisca {
                 plaintext_copy_count = 1;
             } break;
             default: {
-                assert(false);
+                METRISCA_ASSERT_NOT_REACHED();
                 return Error::INVALID_DATA;
             } break;
         }
@@ -480,7 +479,7 @@ namespace metrisca {
                 key_count = 1;
             } break;
             default: {
-                assert(false);
+                METRISCA_ASSERT_NOT_REACHED();
                 return Error::INVALID_DATA;
             } break;
         }

--- a/tools/metriscacli/src/app/application.cpp
+++ b/tools/metriscacli/src/app/application.cpp
@@ -428,28 +428,20 @@ namespace metrisca {
 
     Result<void, Error> Application::HandleMetric(const ArgumentList& arguments)
     {
-        if (arguments.HasArgument("subcommand"))
+        auto metric_name = arguments.GetString("subcommand").value();
+        auto metric_or_error = PluginFactory::The().ConstructAs<MetricPlugin>(PluginType::Metric, metric_name, arguments);
+        if (metric_or_error.IsError())
         {
-            auto metric_name = arguments.GetString("subcommand").value();
-            auto metric_or_error = PluginFactory::The().ConstructAs<MetricPlugin>(PluginType::Metric, metric_name, arguments);
-            if (metric_or_error.IsError())
-            {
-                METRISCA_ERROR("Failed to initialize metric '{0}' with error code {1}: {2}. See 'help metric {0}'.", metric_name, metric_or_error.Error(), ErrorCause(metric_or_error.Error()));
-                return Error::INVALID_ARGUMENT;
-            }
-
-            auto metric = metric_or_error.Value();
-            auto result = metric->Compute();
-            if (result.IsError())
-            {
-                METRISCA_ERROR("Metric failed to compute and exited with error code {}: {}", result.Error(), ErrorCause(result.Error()));
-                return result.Error();
-            }
+            METRISCA_ERROR("Failed to initialize metric '{0}' with error code {1}: {2}. See 'help metric {0}'.", metric_name, metric_or_error.Error(), ErrorCause(metric_or_error.Error()));
+            return Error::INVALID_ARGUMENT;
         }
-        else
+
+        auto metric = metric_or_error.Value();
+        auto result = metric->Compute();
+        if (result.IsError())
         {
-            // FIXME: Handle this case.
-            METRISCA_CRITICAL("Hmm");
+            METRISCA_ERROR("Metric failed to compute and exited with error code {}: {}", result.Error(), ErrorCause(result.Error()));
+            return result.Error();
         }
 
         return {};
@@ -578,13 +570,9 @@ namespace metrisca {
             auto command = GetCommand(name);
             if (command)
             {
-                ArgumentList arguments;
-
                 // We use the default parser for that command unless we find a matching subparser.
-                // In that case, we use the subparser instead and we pass the name of that subparser
-                // as an argument in the argument list. This let's us keep track of which subcommand
-                // is being used.
                 auto parser = command->Parser;
+                std::string subparser_name;
                 std::vector<std::string> command_args(args.begin() + 1, args.end());
                 if (command->SubParsers.size() > 0 && args.size() > 1)
                 {
@@ -593,7 +581,7 @@ namespace metrisca {
                     if (subparser.has_value())
                     {
                         parser = subparser.value();
-                        arguments.SetString("subcommand", subcommand_name);
+                        subparser_name = subcommand_name;
                         command_args = std::vector<std::string>(args.begin() + 2, args.end());
                     }
                     else
@@ -603,6 +591,7 @@ namespace metrisca {
                     }
                 }
 
+                ArgumentList arguments;
                 try 
                 {
                     arguments = parser.Parse(command_args);
@@ -617,6 +606,12 @@ namespace metrisca {
                     std::cout << pe.what() << " See 'help " << parser.FullName() << "'." << std::endl << std::endl;
                     return Error::INVALID_COMMAND;
                 }
+
+                // If we found a matching subparser, we pass the name of that subparser
+                // as an argument in the argument list. This let's us keep track of which subcommand
+                // is being used in the command handler.
+                if (!subparser_name.empty())
+                    arguments.SetString("subcommand", subparser_name);
 
                 auto handler_result = command->Handler(arguments);
                 if (handler_result.IsError())

--- a/tools/metriscacli/src/app/application.cpp
+++ b/tools/metriscacli/src/app/application.cpp
@@ -428,6 +428,8 @@ namespace metrisca {
 
     Result<void, Error> Application::HandleMetric(const ArgumentList& arguments)
     {
+        METRISCA_ASSERT(arguments.HasArgument("subcommand"));
+
         auto metric_name = arguments.GetString("subcommand").value();
         auto metric_or_error = PluginFactory::The().ConstructAs<MetricPlugin>(PluginType::Metric, metric_name, arguments);
         if (metric_or_error.IsError())


### PR DESCRIPTION
The `ArgumentList` containing the `subcommand` argument was subsequently overwritten, causing the argument to be missing in the metrics command handler.

Closes #6 